### PR TITLE
Use return instead of exit in hasValue

### DIFF
--- a/lib/Array.bash
+++ b/lib/Array.bash
@@ -177,10 +177,7 @@ function Array::yield() {
 # $1: arrayname
 # $2: value
 function Array::hasValue() {
-  if ! Array::isValid "$1"; then
-    echo "$(caller): $1 is not a valid array."
-    exit 1
-  fi
+  Array::isValid "$1" || return $?
 
   declare -n array="$1"
 


### PR DESCRIPTION
To be consistent with the rest of the functions,

and let the choice of exiting to the user (set -e, etc.).

See issue GitHub issue GH-2.